### PR TITLE
Resolve overlaps section

### DIFF
--- a/gnuefi/elf_arm_efi.lds
+++ b/gnuefi/elf_arm_efi.lds
@@ -52,6 +52,7 @@ SECTIONS
     *(.rel.reloc)
     *(.eh_frame)
     *(.note.GNU-stack)
+    *(.note.gnu.build-id)
   }
   .comment 0 : { *(.comment) }
 }


### PR DESCRIPTION
section .note.gnu.build-id loaded at [0000000000000000,0000000000000023] overlaps section .text loaded at [0000000000000000,00000000000069af]
