### PR TITLE
make parameter to compile apps + add example output directory

### DIFF
--- a/README.gnuefi
+++ b/README.gnuefi
@@ -108,10 +108,10 @@ the make command line (e.g., "make ARCH=ia64").
 ** Building
 
 To build the sample EFI applications provided in subdirectory "apps",
-simply invoke "make" in the toplevel directory (the directory
+simply invoke "make apps" in the toplevel directory (the directory
 containing this README file).  This should build lib/libefi.a and
 gnuefi/libgnuefi.a first and then all the EFI applications such as a
-apps/t6.efi.
+x86_64/apps/t6.efi.
 
 
 ** Running


### PR DESCRIPTION
The current explanation suggests that "make" also makes the apps, but it seems that "make apps" is necessary. Also, after compiling the apps  I initially searched for the .efi output files in apps/, but eventually found them in x66_64/apps. I grant that this is specific to the x86_64 architecture, but I believe it still more suggestive as to where to look.